### PR TITLE
Fix AI tab sorting (broom button did nothing but animate)

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -2,7 +2,7 @@
   {
     "type": "checkbox",
     "label": "Enable AI",
-    "property": "browser.ml.enabled",
+    "property": "browser.ml.enable",
     "force": true,
     "defaultValue": true
   }

--- a/tidy-tabs.uc.js
+++ b/tidy-tabs.uc.js
@@ -18,6 +18,19 @@
     EXISTING_GROUP_BOOST: 0.1, // Boost similarity score for existing groups to prefer them
   };
 
+  // --- Ensure Firefox's local ML engine is enabled ---
+  // The AI sorting relies on Firefox's local inference runtime, which refuses to
+  // start unless "browser.ml.enable" is true. For Sine installs this is handled by
+  // preferences.json, but manual installs need it set here too. Without it, every
+  // embedding call throws and the sort button only plays its (failure) animation.
+  try {
+    if (!Services.prefs.getBoolPref("browser.ml.enable", false)) {
+      Services.prefs.setBoolPref("browser.ml.enable", true);
+    }
+  } catch (e) {
+    console.error("[TidyTabs] Could not enable browser.ml.enable:", e);
+  }
+
   // --- Globals & State ---
   let isSorting = false;
   let sortButtonListenerAdded = false;
@@ -329,15 +342,31 @@
         engineId: "embedding-engine",
       });
 
-      const result = await engine.run({ args: [title] });
+      // Mirror Firefox's own SmartTabGrouping call: pass the texts as a batch
+      // and request mean pooling + normalization. Without "pooling: mean" the
+      // engine returns the raw per-token tensor instead of a single sentence
+      // vector, which this parser can't use (it would silently yield null and
+      // the sort would always "fail" with just an animation).
+      const result = await engine.run({
+        args: [[title]],
+        options: { pooling: "mean", normalize: true },
+      });
+
+      // The engine returns an array whose first element is the pooled,
+      // normalized sentence vector (extra keys like "metrics" sit alongside it).
       let embedding;
 
       if (result?.[0]?.embedding && Array.isArray(result[0].embedding)) {
         embedding = result[0].embedding;
       } else if (result?.[0] && Array.isArray(result[0])) {
+        // Batched result: an array with one vector per input text.
         embedding = result[0];
-      } else if (Array.isArray(result)) {
+      } else if (Array.isArray(result) && typeof result[0] === "number") {
+        // Engine squeezed the batch dimension and returned a flat vector.
         embedding = result;
+      } else if (result?.data) {
+        // Raw Tensor object ({ data, dims }) — flatten its data buffer.
+        embedding = Array.from(result.data);
       } else {
         return null;
       }


### PR DESCRIPTION
Closes #10.

On a current Zen build the sort/tidy (broom) button just played its animation and never grouped any tabs. I traced it to three separate breaks on the way to Firefox's local ML engine, all fixed here.

### 1. The engine was never enabled
The "Enable AI" preference toggled `browser.ml.enabled` — that pref doesn't exist. Firefox's engine checks `browser.ml.enable` (no trailing "d") and refuses to start otherwise, so every embedding call threw and the sort fell straight through to the failure animation.

- `preferences.json`: `browser.ml.enabled` → `browser.ml.enable`
- `tidy-tabs.uc.js`: also set the pref at startup, so manual / non-Sine installs work without touching `about:config`.

### 2. Embeddings came back unusable
`generateEmbedding` called `engine.run({ args: [title] })` with no pooling option, so `feature-extraction` returned the raw per-token tensor instead of a single sentence vector. The result never matched the parser and silently became `null`, so clustering always saw zero valid embeddings.

Now it mirrors Firefox's own `SmartTabGrouping.sys.mjs` call: batched args plus `{ pooling: "mean", normalize: true }`.

### 3. Result parsing
Hardened to accept the pooled vector (`result[0]`), an already-flattened vector, or a raw `Tensor` (`{ data, dims }`).

### Testing
Verified on Zen (release) via Sine: clicking the broom on 9 ungrouped tabs now produces real groups, e.g.

```
[TabSort] Created new group "Recherche" with 2 tabs
[TabSort] Debug - Sorting failed: false
[TabSort] Reorder - Complete!
```

Before the fix the same action logged `AI returned 0 tab-topic pairs` and triggered the failure animation.